### PR TITLE
Fixing a configuration bug

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ if (config.auth) {
 	server.use(prerender.basicAuth());
 }
 if (config.logger) {
-	server.use(prerender.basicAuth());
+	server.use(prerender.logger());
 }
 server.use(prerender.blacklist());
 server.use(prerender.removeScriptTags());


### PR DESCRIPTION
Enabling the logger was erroneously activating basicAuth not the logger.
